### PR TITLE
入力文章をsessionStorageに一時保存

### DIFF
--- a/src/components/form/InputCard.js
+++ b/src/components/form/InputCard.js
@@ -15,23 +15,21 @@ function InputCard (props) {
   const classes = useStyles();
   
   return (
-    <div>
-      <Paper className={classes.innerPaper}>
-        <Typography
-          variant="h5"
-          component="h5"
-        >{ props.title }</Typography>
-        <TextField
-          placeholder={ props.placeholder }
-          multiline={true}
-          fullWidth={true}
-          rows={1}
-          rowsMax={8}
-          value={props.value}
-          onChange={event => props.onChange(event.target.value)}
-        />
-      </Paper>
-    </div>
+    <Paper className={classes.innerPaper}>
+      <Typography
+        variant="h5"
+        component="h5"
+      >{ props.title }</Typography>
+      <TextField
+        placeholder={ props.placeholder }
+        multiline={true}
+        fullWidth={true}
+        rows={1}
+        rowsMax={8}
+        value={props.value}
+        onChange={event => props.onChange(event.target.value)}
+      />
+    </Paper>
   );
 }
 

--- a/src/containers/form.js
+++ b/src/containers/form.js
@@ -16,14 +16,33 @@ const useStyles = makeStyles({
   }
 });
 
-function Form () {
-  const [done, setDone] = useState('');
-  const [comment, setComment] = useState('');
-  const [todo, setTodo] = useState('');
+function getInitialContent (key) {
+  let doneOnSession = window.sessionStorage.getItem(key);
+  
+  if (doneOnSession === null) {
+    return '';
+  }
 
-  const doneChanger = (newDone) => { setDone(newDone) }
-  const commentChanger = (newComment) => { setComment(newComment) }
-  const todoChanger = (newTodo) => { setTodo(newTodo) }
+  return doneOnSession;
+}
+
+function Form () {
+  const [done, setDone] = useState(getInitialContent('done'));
+  const [comment, setComment] = useState(getInitialContent('comment'));
+  const [todo, setTodo] = useState(getInitialContent('todo'));
+
+  const doneChanger = (newDone) => {
+    setDone(newDone);
+    window.sessionStorage.setItem('done', newDone);
+  }
+  const commentChanger = (newComment) => {
+    setComment(newComment);
+    window.sessionStorage.setItem('comment', newComment);
+  }
+  const todoChanger = (newTodo) => {
+    setTodo(newTodo);
+    window.sessionStorage.setItem('todo', newTodo);
+  }
 
   const messageSender = () => {
     var today = new Date();
@@ -70,12 +89,12 @@ function Form () {
       })
       .then(() => {
         window.localStorage.setItem('last_commit', today.toLocaleDateString());
-
         alert('投稿しました');
 
         setDone('');
         setComment('');
         setTodo('');
+        window.sessionStorage.clear();
       })
       .catch(e => alert(e))
   }


### PR DESCRIPTION
## 目的

文章入力中に何らかの原因でページが変わってしまった場合に、入力した文章が削除されないようにする。

## やったこと

- 入力文書を `sessionStorage` に保存
- マウント時に `sessionStorage` に保存してある文章をフォームに反映
- 文章を送信したとき `sessionStorage` に保存してある文章をクリア